### PR TITLE
Unsatisfied lodash module dependency for Machine.prototype.cache.

### DIFF
--- a/lib/Machine.prototype.cache.js
+++ b/lib/Machine.prototype.cache.js
@@ -1,4 +1,12 @@
 /**
+ * Module dependencies
+ */
+
+var _ = require('lodash');
+
+
+
+/**
  * Provide cache settings.
  * @param  {Object} cacheSettings
  * @chainable


### PR DESCRIPTION
Needed for [line 29](https://github.com/node-machine/machine/blob/8fff8d20d1210247bd9d9474d3eccf7bbc2b084c/lib/Machine.prototype.cache.js#L29), `_.extend`.