### PR TITLE
Ls machine in a new place for direct usage docs.

### DIFF
--- a/docs/DIRECT_USAGE.md
+++ b/docs/DIRECT_USAGE.md
@@ -218,11 +218,11 @@ Machines know how to cache their own results.
 
 ```javascript
 var Machine = require('machine');
-var ls = Machine.build(require('machinepack-fs/ls'));
+var ls = Machine.build(require('machinepack-fs/machine/ls'));
 
 ls
 .configure({
-
+  dir: '.'
 })
 .cache({ttl: 2000}) // this is the ttl, 2000ms === 2 seconds
 .exec(console.log)


### PR DESCRIPTION
Fixes `Cannot find module 'machinepack-fs/ls'`.