### PR TITLE
Clarify why we don't have to worry about the spinlock when encounteri…

### DIFF
--- a/lib/private/intercept-exit-callbacks.js
+++ b/lib/private/intercept-exit-callbacks.js
@@ -129,6 +129,9 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
                   // For any exit other than `error`, if we discover that the effective output example is invalid,
                   // then we trigger the error exit with an error describing what happened.
                   // > See https://github.com/node-machine/machine/commit/54a0fa6875169b8572853a1dc05069da267e2d89#commitcomment-19063423 for debugging notes.
+                  // NOTE we haven't set the machine._exited spinlock yet,
+                  // so it's okay that we're calling the `error` exit
+                  // after having already traversed some other exit.
                   if (exitName !== 'error') {
                     return memo.error(new Error('The effective output example determined for exit (`'+exitName+'`) is not a valid RTTC exemplar: '+util.inspect(example, false, null)));
                   }


### PR DESCRIPTION
…ng an invalid exit output example.