### PR TITLE
Update stack cleanser

### DIFF
--- a/lib/private/remove-non-userland-calls-from-stack.js
+++ b/lib/private/remove-non-userland-calls-from-stack.js
@@ -45,6 +45,9 @@ module.exports = function removeNonUserlandCallsFromStack(stackEntries) {
 
   try {
 
+    var libPrivateDir = __dirname;
+    var libDir = path.resolve(libPrivateDir, '..');
+
     // Loop through the array of stack entries, line by line.
     var prunedStackEntries = _.reduce(stackEntries, function (memo, stackEntry) {
 
@@ -55,11 +58,10 @@ module.exports = function removeNonUserlandCallsFromStack(stackEntries) {
       // Trim whitespace from the path and use path.dirname to get its directory.
       var fileDir = path.dirname(filePath.trim());
 
-      // If the directory is the same as this script's directory
-      // (i.e. the "lib" folder of the machine runner) or if it's
-      // just '.' (indicating an internal Node script), skip it.
-      // Otherwise keep it.
-      if (fileDir !== '.' && fileDir !== __dirname) {
+      // If the directory is the /lib or /lib/private folder
+      // from the machine runner, ignore the entry.  Otherwise
+      // add it to the list.
+      if (fileDir !== libPrivateDir && fileDir !== libDir) {
         memo.push(stackEntry);
       }
 

--- a/lib/private/remove-non-userland-calls-from-stack.js
+++ b/lib/private/remove-non-userland-calls-from-stack.js
@@ -31,9 +31,11 @@ var getFilepathFromStackEntry = require('./get-filepath-from-stack-entry');
  *
  * > - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  * > Specifically, this removes stack entries that originate from within this
- * > package (the machine runner), as well as stack entries referring to files
- * > in Node core.
+ * > package (the machine runner).
  */
+
+var libPrivateDir = __dirname;
+var libDir = path.resolve(libPrivateDir, '..');
 
 module.exports = function removeNonUserlandCallsFromStack(stackEntries) {
 
@@ -42,11 +44,7 @@ module.exports = function removeNonUserlandCallsFromStack(stackEntries) {
     throw new Error('Consistency violation: removeNonUserlandCallsFromStack() expects an array of strings as its 1st argument!  But instead got: '+util.inspect(stackEntries, {depth: null}));
   }
 
-
   try {
-
-    var libPrivateDir = __dirname;
-    var libDir = path.resolve(libPrivateDir, '..');
 
     // Loop through the array of stack entries, line by line.
     var prunedStackEntries = _.reduce(stackEntries, function (memo, stackEntry) {


### PR DESCRIPTION
* Remove entries referencing the `lib/private` folder of the machine runner
* Leave in entries referencing internal Node methods (like `listTimeout`)