### PR TITLE
Moved all stack trace manip under feature flag & published 13.0.0-16

### DIFF
--- a/lib/private/help-exec-machine-instance.js
+++ b/lib/private/help-exec-machine-instance.js
@@ -48,40 +48,49 @@ module.exports = function helpExecMachineInstance (liveMachine) {
   }
 
 
-  // Get a copy of the stack trace for this invocation of .exec().
-  // This will include an error message on the first line,
-  // a reference to this file (prototype.exec.js) on the second line,
-  // and the module that _called_ .exec() on the third line -- that's
-  // what we're after.
-  var thisStack = (new Error()).stack.split('\n');
+  // `thisStack` is only used if the `_doAlterStack` flag is enabled on the live machine instance.
+  // (stack alteration is **experimental** as of machine@v13.x)
+  var thisStack;
+  // ===================================================================================================================
+  if (liveMachine._doAlterStack) {
 
-  // Remove the first line (the error message) from the stack track.
-  thisStack = thisStack.slice(1);
+    // Get a copy of the stack trace for this invocation of .exec().
+    // This will include an error message on the first line,
+    // a reference to this file (prototype.exec.js) on the second line,
+    // and the module that _called_ .exec() on the third line -- that's
+    // what we're after.
+    thisStack = (new Error()).stack.split('\n');
 
-  // Remove all non-userland calls (i.e. calls from the machine runner or internal to Node).
-  thisStack = removeNonUserlandCallsFromStack(thisStack);
+    // Remove the first line (the error message) from the stack track.
+    thisStack = thisStack.slice(1);
 
-  // Ensure that there is a 'debug' dictionary in the environment, with at least a stacks array.
-  _.defaultsDeep(liveMachine._configuredEnvironment, {debug: {stack: []}});
+    // Remove all non-userland calls (i.e. calls from the machine runner or internal to Node).
+    thisStack = removeNonUserlandCallsFromStack(thisStack);
 
-  // Get the last caller before the current one
-  var lastCaller = liveMachine._configuredEnvironment.debug.stack.length && _.last(liveMachine._configuredEnvironment.debug.stack)[0];
+    // Ensure that there is a 'debug' dictionary in the environment, with at least a stacks array.
+    _.defaultsDeep(liveMachine._configuredEnvironment, {debug: {stack: []}});
 
-  // If the stack is empty, use the entire contents of thisStack to start us off.
-  // This ensures we keep the trace going back to before the first machine
-  // was called  (for example the trace into Sails).
-  if (liveMachine._configuredEnvironment.debug.stack.length === 0) {
-    liveMachine._configuredEnvironment.debug.stack = _.clone(thisStack).reverse();
-  }
-  // Otherwise just push the first line of thisStack, since the rest of it
-  // (if there is any) will be duplicative.
-  else {
-    liveMachine._configuredEnvironment.debug.stack.push(thisStack[0]);
-  }
+    // Get the last caller before the current one
+    var lastCaller = liveMachine._configuredEnvironment.debug.stack.length && _.last(liveMachine._configuredEnvironment.debug.stack)[0];
 
-  // console.log('`' + liveMachine.identity + '`.exec stacks:');
-  // console.log(liveMachine._configuredEnvironment.debug.stack);
-  // console.log('-----');
+    // If the stack is empty, use the entire contents of thisStack to start us off.
+    // This ensures we keep the trace going back to before the first machine
+    // was called  (for example the trace into Sails).
+    if (liveMachine._configuredEnvironment.debug.stack.length === 0) {
+      liveMachine._configuredEnvironment.debug.stack = _.clone(thisStack).reverse();
+    }
+    // Otherwise just push the first line of thisStack, since the rest of it
+    // (if there is any) will be duplicative.
+    else {
+      liveMachine._configuredEnvironment.debug.stack.push(thisStack[0]);
+    }
+
+    // console.log('`' + liveMachine.identity + '`.exec stacks:');
+    // console.log(liveMachine._configuredEnvironment.debug.stack);
+    // console.log('-----');
+  }//>-
+  // ===================================================================================================================
+
 
   // If duration-tracking is enabled, track current timestamp
   // as a JavaScript Date instance in `_execBeginTimestamp`.
@@ -154,31 +163,44 @@ module.exports = function helpExecMachineInstance (liveMachine) {
         // Build an appropriate runtime validation error.
         var err_machineRuntimeValidation = (function _buildMachineRuntimeValidationErr() {
 
-          // Start with a new Error.
-          var err_machineRuntimeValidation = new Error();
-
-          // If there's a stack trace in the environment, it means that somewhere along the way
-          // some asynchronous code was run that would cause the natural stack trace to be
-          // truncated, so the stack up to that point was saved so we can add it to our stack now
-          // and get the full history.
-          err_machineRuntimeValidation.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
-
-          // Improve the error msg, and then update the stack so it has the message up top (like it OUGHT)
+          // Build a nice error msg
           var bulletPrefixedErrors = _.map(errors, function (rttcValidationErr){ return '  • '+rttcValidationErr.message; });
           var prettyPrintedValidationErrorsStr = bulletPrefixedErrors.join('\n');
           var errMsg = 'Could not run `'+liveMachine.identity+'` due to '+errors.length+' '+
           'validation error'+(errors.length>1?'s':'')+':\n'+prettyPrintedValidationErrorsStr;
-          err_machineRuntimeValidation.message = errMsg;
-          err_machineRuntimeValidation.stack = 'Error: ' + errMsg + '\n' + err_machineRuntimeValidation.stack;
+
+
+          var _err_machineRuntimeValidation;
+
+          // ===================================================================================================================
+          if (liveMachine._doAlterStack) {
+
+            // Start with a new Error.
+            _err_machineRuntimeValidation = new Error();
+
+            // If there's a stack trace in the environment, it means that somewhere along the way
+            // some asynchronous code was run that would cause the natural stack trace to be
+            // truncated, so the stack up to that point was saved so we can add it to our stack now
+            // and get the full history.
+            _err_machineRuntimeValidation.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
+
+            // Then update the stack so it has the message up top (like it OUGHT)
+            _err_machineRuntimeValidation.message = errMsg;
+            _err_machineRuntimeValidation.stack = 'Error: ' + errMsg + '\n' + _err_machineRuntimeValidation.stack;
+          }
+          // ===================================================================================================================
+          else {
+            _err_machineRuntimeValidation = new Error(errMsg);
+          }
 
           // Give it that code, so we can negotiate it.  And add a reference to the machine instance,
           // so intermediate tooling like machine-as-action can tell which validation error is which.
           // And finally, provide a reference to the raw RTTC validation errors for userland analysis.
-          err_machineRuntimeValidation.code = 'E_MACHINE_RUNTIME_VALIDATION';
-          err_machineRuntimeValidation.machineInstance = liveMachine;
-          err_machineRuntimeValidation.errors = errors;
+          _err_machineRuntimeValidation.code = 'E_MACHINE_RUNTIME_VALIDATION';
+          _err_machineRuntimeValidation.machineInstance = liveMachine;
+          _err_machineRuntimeValidation.errors = errors;
 
-          return err_machineRuntimeValidation;
+          return _err_machineRuntimeValidation;
 
         })();//</self-calling function :: built a E_MACHINE_RUNTIME_VALIDATON error>
         // --
@@ -651,20 +673,33 @@ module.exports = function helpExecMachineInstance (liveMachine) {
           errMsg += ' with: \n\n' + util.inspect(_resultPassedInByMachineFn, {depth: null});
         }
 
-        // Start with a new Error.
-        var err_forwarding = new Error();
+        // Build our forwarding Error.
+        var err_forwarding;
 
-        // If there's a stack trace in the environment, it means that somewhere along the way
-        // some asynchronous code was run that would cause the natural stack trace to be
-        // truncated, so the stack up to that point was saved so we can add it to our stack now
-        // and get the full history.
-        err_forwarding.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
-        // Indicate that we've already massaged this stack, so we don't do it again.
-        Object.defineProperty(err_forwarding, 'stackModified', {value: true});
+        // ===================================================================================================================
+        if (liveMachine._doAlterStack) {
 
-        // Copy our error message
-        err_forwarding.message = errMsg;
-        err_forwarding.stack = 'Error: ' + errMsg + '\n' + err_forwarding.stack;
+          // Start with a new Error.
+          err_forwarding = new Error();
+
+          // If there's a stack trace in the environment, it means that somewhere along the way
+          // some asynchronous code was run that would cause the natural stack trace to be
+          // truncated, so the stack up to that point was saved so we can add it to our stack now
+          // and get the full history.
+          err_forwarding.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
+          // Indicate that we've already massaged this stack, so we don't do it again.
+          Object.defineProperty(err_forwarding, 'stackModified', {value: true});
+
+          // Copy our error message
+          err_forwarding.message = errMsg;
+          err_forwarding.stack = 'Error: ' + errMsg + '\n' + err_forwarding.stack;
+        }
+        // ===================================================================================================================
+        else {
+          err_forwarding = new Error(errMsg);
+        }
+
+        // Attach `exit` property.
         err_forwarding.exit = exitCodeName;
         err_forwarding.code = exitCodeName;
 
@@ -755,9 +790,14 @@ module.exports = function helpExecMachineInstance (liveMachine) {
           'your machine definition).  To disable this protection, set `timeout` to 0.');
           err.code = 'E_MACHINE_TIMEOUT';
 
-          err.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
-          // Indicate that we've already massaged this stack, so we don't do it again.
-          Object.defineProperty(err, 'stackModified', {value: true});
+          // ===================================================================================================================
+          if (liveMachine._doAlterStack) {
+            err.stack = getCombinedErrorStack(thisStack, liveMachine._configuredEnvironment.debug.stack);
+
+            // Indicate that we've already massaged this stack, so we don't do it again.
+            Object.defineProperty(err, 'stackModified', {value: true});
+          }//>-
+          // ===================================================================================================================
 
           // Trigger callback
           implementorSwitchback.error(err);
@@ -805,28 +845,34 @@ module.exports = function helpExecMachineInstance (liveMachine) {
         liveMachine.fn.apply(liveMachine._configuredEnvironment, [liveMachine._configuredInputs, implementorSwitchback, liveMachine._configuredEnvironment]);
       } catch (e) {
 
-        // Create a new stack trace for the error, using the stack we've been building up in
-        // _configuredEnvironment in order to preserve the stack after asynchronous jumps.
-        var newStackTrace = (function() {
-          // First, strip the error name and message off the stack trace string.
-          var traceWithoutMessage = getStackTraceWithoutInitialMessage(e);
-          // Then split it into lines.
-          var traceLines = traceWithoutMessage.split('\n');
-          // Remove lines which refer to non-userland calls
-          traceLines = removeNonUserlandCallsFromStack(traceLines);
-          // Intelligently combine those lines with the ones we've been building up
-          // in the _configuredEnvironment.debug.stack, and get a string back.
-          var combinedTrace = getCombinedErrorStack(traceLines, liveMachine._configuredEnvironment.debug.stack);
-          // Finally, add the error name and message back in.
-          combinedTrace = e.name + ': ' + e.message + '\n' + combinedTrace;
-          return combinedTrace;
-        })();
+        // ===================================================================================================================
+        if (liveMachine._doAlterStack) {
 
-        // Set the stack trace of the error to the new one we created.
-        e.stack = newStackTrace;
+          // Create a new stack trace for the error, using the stack we've been building up in
+          // _configuredEnvironment in order to preserve the stack after asynchronous jumps.
+          var newStackTrace = (function() {
+            // First, strip the error name and message off the stack trace string.
+            var traceWithoutMessage = getStackTraceWithoutInitialMessage(e);
+            // Then split it into lines.
+            var traceLines = traceWithoutMessage.split('\n');
+            // Remove lines which refer to non-userland calls
+            traceLines = removeNonUserlandCallsFromStack(traceLines);
+            // Intelligently combine those lines with the ones we've been building up
+            // in the _configuredEnvironment.debug.stack, and get a string back.
+            var combinedTrace = getCombinedErrorStack(traceLines, liveMachine._configuredEnvironment.debug.stack);
+            // Finally, add the error name and message back in.
+            combinedTrace = e.name + ': ' + e.message + '\n' + combinedTrace;
+            return combinedTrace;
+          })();
 
-        // Indicate that we've already massaged this stack, so we don't do it again.
-        Object.defineProperty(e, 'stackModified', {value: true});
+          // Set the stack trace of the error to the new one we created.
+          e.stack = newStackTrace;
+
+          // Indicate that we've already massaged this stack, so we don't do it again.
+          Object.defineProperty(e, 'stackModified', {value: true});
+
+        }//>-
+        // ===================================================================================================================
 
         // If it throws an uncaught error *that we can catch* (i.e. outside of any asynchronous callbacks),
         // then catch it and trigger the configured `error` callback.

--- a/lib/private/intercept-exit-callbacks.js
+++ b/lib/private/intercept-exit-callbacks.js
@@ -26,11 +26,11 @@ var getStackTraceWithoutInitialMessage = require('./get-stack-trace-without-init
  * @param  {Dictionary} callbacks  - a dictionary of callback functions, with a key for each configured exit
  * @param  {Dictionary|false} _cache  - the cache configuration (or `false` if it's not in use)
  * @param  {String} hash?  - the hash string representing this particular input configuration (if the cache is not in use, this is always `undefined`)
- * @param  {Dictionary} machine - the live machine instance
+ * @param  {Dictionary} liveMachine - the live machine instance
  *
  * @return {Dictionary} of new callbacks which intercept the configured callback functions
  */
-module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machine){
+module.exports = function interceptExitCallbacks (callbacks, _cache, hash, liveMachine){
 
   var interceptedCallbacks = _.reduce(callbacks, function (memo,fn,exitName){
 
@@ -46,23 +46,30 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
     // Set up an intercept function that will wrap the callback.
     memo[exitName] = function _interceptExit(value) {
 
-      var thisStack = (new Error()).stack.split('\n');
+      // `thisStack` is only used if the `_doAlterStack` flag is enabled on the live machine instance.
+      // (stack alteration is **experimental** as of machine@v13.x)
+      var thisStack;
+      // ===================================================================================================================
+      if (liveMachine._doAlterStack) {
+        thisStack = (new Error()).stack.split('\n');
 
-      // Remove the first line (the error message) from the stack track.
-      thisStack = thisStack.slice(1);
+        // Remove the first line (the error message) from the stack track.
+        thisStack = thisStack.slice(1);
 
-      // Remove all non-userland calls (i.e. calls from the machine runner or internal to Node).
-      thisStack = removeNonUserlandCallsFromStack(thisStack);
+        // Remove all non-userland calls (i.e. calls from the machine runner or internal to Node).
+        thisStack = removeNonUserlandCallsFromStack(thisStack);
+      }//>-
+      // ===================================================================================================================
 
       // If the machine has already timed out, then we should bail.
-      if (machine._timedOut) {
+      if (liveMachine._timedOut) {
         return;
       }// --•
 
       // Assert that our `_exited` spinlock has not already been set.
       // If it has, log a warning and bail.
-      if (machine._exited) {
-        console.warn('In machine `'+_.camelCase(machine.identity)+'`: attempted to call exit `'+exitName+'` after exit `'+machine._exited+'` was already triggered.  If you are the maintainer of this machine, make sure your machine only ever calls one exit, exactly once!');
+      if (liveMachine._exited) {
+        console.warn('In machine `'+_.camelCase(liveMachine.identity)+'`: attempted to call exit `'+exitName+'` after exit `'+liveMachine._exited+'` was already triggered.  If you are the maintainer of this machine, make sure your machine only ever calls one exit, exactly once!');
         return;
       }// --•
 
@@ -86,11 +93,11 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
         if (err) {
           // If cache write encounters an error, emit a warning but
           // continue with sending back the output.
-          machine.warn(err);
+          liveMachine.warn(err);
         }// >-
 
         // Look up appropriate exit definition.
-        var exitDef = machine.exits && machine.exits[exitName];
+        var exitDef = liveMachine.exits && liveMachine.exits[exitName];
 
         // Determine if the exit has been explicitly "voided".
         // TODO: deprecate this
@@ -99,18 +106,18 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
         })();
 
         // Coerce exit's output value (if `_exitCoercion` flag enabled)
-        if(machine._exitCoercion && !voided) {
+        if(liveMachine._exitCoercion && !voided) {
 
           // Get exit's example if possible
           // (will run the exit's getExample() function, or apply its `like` or `itemOf` reference)
           var example;
           try {
-            example = determineEffectiveOutputExample(exitDef, exitName, machine._configuredInputs, machine);
+            example = determineEffectiveOutputExample(exitDef, exitName, liveMachine._configuredInputs, liveMachine);
           }
           catch (e) {
             // If we encounter an error attempting to figure out the effective output example,
             // emit a warning, but then continue on sending back the output below.
-            machine.warn('Encountered issue when attempting to determine example of '+exitName+' exit in machine ('+machine.identity+'): ' + e.stack);
+            liveMachine.warn('Encountered issue when attempting to determine example of '+exitName+' exit in machine ('+liveMachine.identity+'): ' + e.stack);
           }
           // >-
 
@@ -146,7 +153,7 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
 
                 // Misc unrecognized error:
                 default:
-                  throw new Error('Consistency violation: Encountered unexpected internal error in machine runner when attempting to coerce output for exit (`'+exitName+'`) of machine (`'+machine.identity+'`).  Details: '+e.stack);
+                  throw new Error('Consistency violation: Encountered unexpected internal error in machine runner when attempting to coerce output for exit (`'+exitName+'`) of machine (`'+liveMachine.identity+'`).  Details: '+e.stack);
 
               }//</switch>
             }//</catch :: error inferring type schema or coercing against it>
@@ -157,7 +164,7 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
         (function maybeWait(proceed){
 
           // In order to allow for synchronous usage, `sync` must be explicitly `true`.
-          if (machine._runningSynchronously) {
+          if (liveMachine._runningSynchronously) {
             return proceed();
           }
           setTimeout(function (){
@@ -179,40 +186,40 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
           }
 
           var DEBUG_LOG_LINE_LEN = 45;
-          var identity = machine.identity;
+          var identity = liveMachine.identity;
           var paddedIdentity = _.padRight(_.trunc('machine-log:'+identity, {length: DEBUG_LOG_LINE_LEN, omission: ''}), DEBUG_LOG_LINE_LEN);
 
-          Debug('machine:'+machine.identity+':exec')('%s',machine._exited);
-          Debug(paddedIdentity)('     \\_ %s',machine._exited);
+          Debug('machine:'+liveMachine.identity+':exec')('%s',liveMachine._exited);
+          Debug(paddedIdentity)('     \\_ %s',liveMachine._exited);
 
 
           var msElapsed;
-          if (machine._doTrackDuration){
-            machine._execFinishTimestamp = new Date();
+          if (liveMachine._doTrackDuration){
+            liveMachine._execFinishTimestamp = new Date();
             try {
-              msElapsed = machine._execFinishTimestamp.getTime() - machine._execBeginTimestamp.getTime();
-              machine._msElapsed = msElapsed;
+              msElapsed = liveMachine._execFinishTimestamp.getTime() - liveMachine._execBeginTimestamp.getTime();
+              liveMachine._msElapsed = msElapsed;
             }
             catch (e) {
-              machine.warn('Error calculating duration of machine execution:\n',e);
+              liveMachine.warn('Error calculating duration of liveMachine execution:\n',e);
             }
           }
-          if (machine._isLogEnabled) {
+          if (liveMachine._isLogEnabled) {
             try {
-              machine._output = value;
-              machine._onInvoke(machine);
+              liveMachine._output = value;
+              liveMachine._onInvoke(liveMachine);
             }
             catch (e) {
-              machine.warn('Error logging machine info\n:',e);
+              liveMachine.warn('Error logging liveMachine info\n:',e);
             }
           }
 
           // Clear timeout alarm so the error exit callback isn't fired after we're done.
-          clearTimeout(machine._timeoutAlarm);
+          clearTimeout(liveMachine._timeoutAlarm);
 
-          // Set the `._exited` property to indicate that the machine instance's `fn`
+          // Set the `._exited` property to indicate that the liveMachine instance's `fn`
           // has attempted to trigger an exit callback.
-          machine._exited = exitName;
+          liveMachine._exited = exitName;
 
           //  ┌─┐┌┐┌┌─┐┬ ┬┬─┐┌─┐  ┌─┐┬─┐┬─┐┌─┐┬─┐  ┌─┐─┐ ┬┬┌┬┐  ┌─┐┬ ┬┌┬┐┌─┐┬ ┬┌┬┐  ┬┌─┐  ┌─┐┌┐┌
           //  ├┤ │││└─┐│ │├┬┘├┤   ├┤ ├┬┘├┬┘│ │├┬┘  ├┤ ┌┴┬┘│ │   │ ││ │ │ ├─┘│ │ │   │└─┐  ├─┤│││
@@ -223,35 +230,50 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
           //
           // If the error exit is being called, make sure the value is an error instance.
           if (exitName === 'error') {
+
             // If the value is not an error instance, make it one, copying the original value
-            // to the `output` property, and copy the stack from `thisStack` created at the
-            // beginning of this function _before_ the setTimeout().
+            // to the `output` property
             if (!_.isError(value)) {
+
               var oldValue = value;
               // Create a new, descriptive error.
-              value = new Error('Machine `' + machine.identity + '` called its `error` exit with:\n\n' + util.inspect(oldValue, {depth: null}));
+              value = new Error('Machine `' + liveMachine.identity + '` called its `error` exit with:\n\n' + util.inspect(oldValue, {depth: null}));
               // Set the original value as the `output` property of the error.
               value.output = oldValue;
-              // Set the new error's stack to that of `thisStack`, with the error message prepended.
-              // We prepend the message because the code below that modifies the stack expects
-              // it to be there.
-              value.stack = value.message + '\n' + thisStack.join('\n');
-            }
 
-            //  ┌─┐─┐ ┬┌─┐┌─┐┌┐┌┌┬┐  ┌─┐┌┬┐┌─┐┌─┐┬┌─  ┌─┐┌─┐┬─┐  ┌─┐┬─┐┬─┐┌─┐┬─┐  ┌─┐┬ ┬┌┬┐┌─┐┬ ┬┌┬┐
-            //  ├┤ ┌┴┬┘├─┘├─┤│││ ││  └─┐ │ ├─┤│  ├┴┐  ├┤ │ │├┬┘  ├┤ ├┬┘├┬┘│ │├┬┘  │ ││ │ │ ├─┘│ │ │
-            //  └─┘┴ └─┴  ┴ ┴┘└┘─┴┘  └─┘ ┴ ┴ ┴└─┘┴ ┴  └  └─┘┴└─  └─┘┴└─┴└─└─┘┴└─  └─┘└─┘ ┴ ┴  └─┘ ┴
-            //
-            // At this point, the value is guaranteed to be an error instance.
-            // But it may or may not have already had its stack combined with
-            // the stacks in the environment.  If not, we'll do it now.
-            if (!value.stackModified) {
-              value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), machine._configuredEnvironment.debug.stack);
-              // Indicate that we've already massaged this stack, so we don't do it again.
-              Object.defineProperty(value, 'stackModified', {value: true});
-            }
-          }
+              // ===================================================================================================================
+              if (liveMachine._doAlterStack) {
+                // Finally, copy the stack from `thisStack` created at the
+                // beginning of this function _before_ the setTimeout().
 
+                // Set the new error's stack to that of `thisStack`, with the error message prepended.
+                // We prepend the message because the code below that modifies the stack expects
+                // it to be there.
+                value.stack = value.message + '\n' + thisStack.join('\n');
+              }//>-
+              // ===================================================================================================================
+
+            }//</if output is NOT an error instance>
+
+            // ===================================================================================================================
+            if (liveMachine._doAlterStack) {
+              //  ┌─┐─┐ ┬┌─┐┌─┐┌┐┌┌┬┐  ┌─┐┌┬┐┌─┐┌─┐┬┌─  ┌─┐┌─┐┬─┐  ┌─┐┬─┐┬─┐┌─┐┬─┐  ┌─┐┬ ┬┌┬┐┌─┐┬ ┬┌┬┐
+              //  ├┤ ┌┴┬┘├─┘├─┤│││ ││  └─┐ │ ├─┤│  ├┴┐  ├┤ │ │├┬┘  ├┤ ├┬┘├┬┘│ │├┬┘  │ ││ │ │ ├─┘│ │ │
+              //  └─┘┴ └─┴  ┴ ┴┘└┘─┴┘  └─┘ ┴ ┴ ┴└─┘┴ ┴  └  └─┘┴└─  └─┘┴└─┴└─└─┘┴└─  └─┘└─┘ ┴ ┴  └─┘ ┴
+              //
+              // At this point, the value is guaranteed to be an error instance.
+              // But it may or may not have already had its stack combined with
+              // the stacks in the environment.  If not, we'll do it now.
+              if (!value.stackModified) {
+                value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), liveMachine._configuredEnvironment.debug.stack);
+                // Indicate that we've already massaged this stack, so we don't do it again.
+                Object.defineProperty(value, 'stackModified', {value: true});
+              }
+            }//>-
+            // ===================================================================================================================
+
+          }//</if this is the error exit>
+          //‡
           //  ╔═╗┌┬┐┌┬┐  ┌─┐┬ ┬┌┬┐┌─┐┬ ┬┌┬┐  ┌─┐┌─┐┬─┐  ┬  ┬┌─┐┬┌┬┐  ┌┬┐┬┌─┐┌─┐  ┌─┐─┐ ┬┬┌┬┐┌─┐
           //  ╠═╣ ││ ││  │ ││ │ │ ├─┘│ │ │   ├┤ │ │├┬┘  └┐┌┘│ ││ ││  ││││└─┐│    ├┤ ┌┴┬┘│ │ └─┐
           //  ╩ ╩─┴┘─┴┘  └─┘└─┘ ┴ ┴  └─┘ ┴   └  └─┘┴└─   └┘ └─┘┴─┴┘  ┴ ┴┴└─┘└─┘  └─┘┴ └─┴ ┴ └─┘
@@ -259,43 +281,61 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, machi
           else if (exitName !== 'success' && _.isUndefined(example) && _.isUndefined(value)) {
             // Create a new error with the name of the machine and exit that was triggered, and the description
             // of that exit if available.
-            value = new Error('Machine `' + machine.identity + '` called its `' + exitName + '` exit' + (exitDef.description ? (': ' + exitDef.description) : '.'));
-            // Make sure the error stack reaches all the way back to the beginning of the run, following asynchronous hops.
-            value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), machine._configuredEnvironment.debug.stack);
-            // Indicate that we've already massaged this stack, so we don't do it again.
-            Object.defineProperty(value, 'stackModified', {value: true});
-          }
+            value = new Error('Machine `' + liveMachine.identity + '` called its `' + exitName + '` exit' + (exitDef.description ? (': ' + exitDef.description) : '.'));
 
+            // ===================================================================================================================
+            if (liveMachine._doAlterStack) {
+              // Make sure the error stack reaches all the way back to the beginning of the run, following asynchronous hops.
+              value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), liveMachine._configuredEnvironment.debug.stack);
+              // Indicate that we've already massaged this stack, so we don't do it again.
+              Object.defineProperty(value, 'stackModified', {value: true});
+            }//>-
+            // ===================================================================================================================
+
+          }//</else if not success exit, there is no runtime output, and that's what the exit was expcting (i.e. was expecting void)>
+          //‡
           //  If the void exit is called with non-error output (this is weird but permissable)
           else if (exitName !== 'success' && _.isUndefined(example) && !_.isError(value)) {
             // Create a new error with the name of the machine and exit that was triggered, and the description
             // of that exit if available.
-            value = new Error('Machine `' + machine.identity + '` called its `' + exitName + '` exit with:\n\n' + util.inspect(value, {depth: null}));
-            // Make sure the error stack reaches all the way back to the beginning of the run, following asynchronous hops.
-            value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), machine._configuredEnvironment.debug.stack);
-            // Indicate that we've already massaged this stack, so we don't do it again.
-            Object.defineProperty(value, 'stackModified', {value: true});
-          }
+            value = new Error('Machine `' + liveMachine.identity + '` called its `' + exitName + '` exit with:\n\n' + util.inspect(value, {depth: null}));
+
+            // ===================================================================================================================
+            if (liveMachine._doAlterStack) {
+              // Make sure the error stack reaches all the way back to the beginning of the run, following asynchronous hops.
+              value.stack = value.name + ': ' + value.message + '\n' + getCombinedErrorStack(getStackTraceWithoutInitialMessage(value).split('\n'), liveMachine._configuredEnvironment.debug.stack);
+              // Indicate that we've already massaged this stack, so we don't do it again.
+              Object.defineProperty(value, 'stackModified', {value: true});
+            }//>-
+            // ===================================================================================================================
+
+          }//</else if not success exit, and there IS runtime output other than an Error instance, but that's NOT what the exit was expecting (i.e. it was expecting void)>
+
+          //>-
 
           // TODO -- Handle the case of a "void" exit that nevertheless is called with an Error instance
           // as output, using some code like the blocks above.  The trick is to make sure any metadata
           // that the machine runner adds to the exit (".exit", ".output", etc.) is maintained while we
           // also enhance the stack and error message.
 
-          //  ┬ ┬┌─┐┌┬┐┌─┐┌┬┐┌─┐  ┌─┐┌┐┌┬  ┬  ┌─┐┌┬┐┌─┐┌─┐┬┌─
-          //  │ │├─┘ ││├─┤ │ ├┤   ├┤ │││└┐┌┘  └─┐ │ ├─┤│  ├┴┐
-          //  └─┘┴  ─┴┘┴ ┴ ┴ └─┘  └─┘┘└┘ └┘   └─┘ ┴ ┴ ┴└─┘┴ ┴
-          //  Leaving through an exit means popping something off the stack
+          // ===================================================================================================================
+          if (liveMachine._doAlterStack) {
+            //  ┬ ┬┌─┐┌┬┐┌─┐┌┬┐┌─┐  ┌─┐┌┐┌┬  ┬  ┌─┐┌┬┐┌─┐┌─┐┬┌─
+            //  │ │├─┘ ││├─┤ │ ├┤   ├┤ │││└┐┌┘  └─┐ │ ├─┤│  ├┴┐
+            //  └─┘┴  ─┴┘┴ ┴ ┴ └─┘  └─┘┘└┘ └┘   └─┘ ┴ ┴ ┴└─┘┴ ┴
+            //  Leaving through an exit means popping something off the stack
 
-          // Pop the last entry off our stack
-          var lastStackEntry = machine._configuredEnvironment.debug.stack.pop();
+            // Pop the last entry off our stack
+            var lastStackEntry = liveMachine._configuredEnvironment.debug.stack.pop();
 
-          // console.log('`' + machine.identity + '`.exit ('+exitName+') stacks:');
-          // console.log(machine._configuredEnvironment.debug.stack);
-          // console.log('=====');
+            // console.log('`' + liveMachine.identity + '`.exit ('+exitName+') stacks:');
+            // console.log(liveMachine._configuredEnvironment.debug.stack);
+            // console.log('=====');
+          }//>-
+          // ===================================================================================================================
 
           // Call the configured callback for this exit
-          return fn.call(machine._configuredEnvironment, value);
+          return fn.call(liveMachine._configuredEnvironment, value);
 
 
         });//</self-calling function :: _maybeWait()>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine",
-  "version": "13.0.0-15",
+  "version": "13.0.0-16",
   "description": "Configure and execute machines",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For the time being, decided to push off all stack trace manipulation stuff until a future release when we have more time to optimize (currently, it causes a 2-4x performance hit every time .exec() is called-- due in part to [accessing `.stack`](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=captains%20log%20kevinburke), but also just because it's doing more processing and building objects).  Because we've spent so much time on it already, rather than rip it out, I left it in place under a flag.  Some time in the second half of 2017, we'll be able to come back to this and optimize accordingly.

## 13.0.0-16

```
   o                               
                                    
       •                            
      o                  .          
       •                •            
        •                •           
                •       o            
                            •        o
 o   •              •          o   •
      o              o         •    
  •  •      •       •      •    •    
           •      •              o  
  •    b e n c h m a r k s      •    
   •        •                        
 •                        ___  •    
    • o •    •      •    /o/•\_   • 
       •   •  o    •    /_/\ o \_ • 
       o    O   •   o • •   \ o .\_    
          •       o  •       \. O  \   

 • sanity_check x 386,695 ops/sec ±2.89% (72 runs sampled)
 • build_very_simple_machine x 87,049 ops/sec ±4.48% (66 runs sampled)
 • build_machine_with_inputs_and_exits_but_nothing_crazy x 50,111 ops/sec ±2.92% (71 runs sampled)
 • build_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 51,790 ops/sec ±3.60% (64 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits x 25,862 ops/sec ±3.68% (62 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 26,399 ops/sec ±3.39% (62 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 29,054 ops/sec ±3.92% (65 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 27,860 ops/sec ±3.24% (63 runs sampled)
Fastest is sanity_check
Slowest is build_machine_with_crazy_numbers_of_inputs_and_exits,build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable

  ․ • sanity_check x 385,175 ops/sec ±2.38% (75 runs sampled)
 • exec_very_simple_machine x 564 ops/sec ±1.44% (72 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 517 ops/sec ±1.63% (70 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 396 ops/sec ±2.10% (74 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 431 ops/sec ±1.72% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 435 ops/sec ±2.29% (71 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 206 ops/sec ±2.71% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 474 ops/sec ±1.92% (74 runs sampled)
Fastest is sanity_check
Slowest is exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
․ • sanity_check x 380,908 ops/sec ±2.59% (71 runs sampled)
 • execSync_very_simple_machine x 10,034 ops/sec ±4.87% (65 runs sampled)
 • execSync_machine_with_inputs_and_exits_but_nothing_crazy x 7,494 ops/sec ±4.61% (65 runs sampled)
 • execSync_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 2,140 ops/sec ±3.38% (68 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits x 2,868 ops/sec ±5.16% (67 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 3,011 ops/sec ±4.22% (67 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 540 ops/sec ±3.76% (71 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 4,368 ops/sec ±3.05% (70 runs sampled)
Fastest is sanity_check
Slowest is execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars

```



## vs. 13.0.0-15:

```
                                   
   o                               
                                    
       •                            
      o                  .          
       •                •            
        •                •           
                •       o            
                            •        o
 o   •              •          o   •
      o              o         •    
  •  •      •       •      •    •    
           •      •              o  
  •    b e n c h m a r k s      •    
   •        •                        
 •                        ___  •    
    • o •    •      •    /o/•\_   • 
       •   •  o    •    /_/\ o \_ • 
       o    O   •   o • •   \ o .\_    
          •       o  •       \. O  \   

 • sanity_check x 404,015 ops/sec ±2.70% (74 runs sampled)
 • build_very_simple_machine x 99,392 ops/sec ±3.67% (69 runs sampled)
 • build_machine_with_inputs_and_exits_but_nothing_crazy x 49,529 ops/sec ±2.50% (71 runs sampled)
 • build_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 52,947 ops/sec ±3.09% (70 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits x 28,035 ops/sec ±3.07% (66 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 26,307 ops/sec ±3.62% (65 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 31,851 ops/sec ±3.52% (67 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 27,249 ops/sec ±3.58% (67 runs sampled)
Fastest is sanity_check
Slowest is build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable,build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars

  ․ • sanity_check x 365,811 ops/sec ±1.90% (74 runs sampled)
 • exec_very_simple_machine x 372 ops/sec ±2.08% (71 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 355 ops/sec ±1.59% (71 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 291 ops/sec ±2.20% (71 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 313 ops/sec ±1.73% (74 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 308 ops/sec ±2.00% (72 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 178 ops/sec ±1.91% (75 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 329 ops/sec ±1.51% (74 runs sampled)
Fastest is sanity_check
Slowest is exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
․ • sanity_check x 350,532 ops/sec ±1.74% (73 runs sampled)
 • execSync_very_simple_machine x 1,574 ops/sec ±3.82% (68 runs sampled)
 • execSync_machine_with_inputs_and_exits_but_nothing_crazy x 1,445 ops/sec ±2.81% (71 runs sampled)
 • execSync_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 918 ops/sec ±3.09% (71 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits x 1,065 ops/sec ±3.29% (69 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 1,103 ops/sec ±3.44% (69 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 422 ops/sec ±2.59% (72 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 1,326 ops/sec ±4.62% (71 runs sampled)
Fastest is sanity_check
Slowest is execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
```

## vs 12.4.0

```
   o                               
                                    
       •                            
      o                  .          
       •                •            
        •                •           
                •       o            
                            •        o
 o   •              •          o   •
      o              o         •    
  •  •      •       •      •    •    
           •      •              o  
  •    b e n c h m a r k s      •    
   •        •                        
 •                        ___  •    
    • o •    •      •    /o/•\_   • 
       •   •  o    •    /_/\ o \_ • 
       o    O   •   o • •   \ o .\_    
          •       o  •       \. O  \   

 • sanity_check x 400,154 ops/sec ±2.08% (74 runs sampled)
 • build_very_simple_machine x 19,775 ops/sec ±3.66% (70 runs sampled)
 • build_machine_with_inputs_and_exits_but_nothing_crazy x 13,666 ops/sec ±2.41% (72 runs sampled)
 • build_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 14,513 ops/sec ±2.32% (68 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits x 11,733 ops/sec ±2.97% (71 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 11,182 ops/sec ±2.83% (70 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 11,132 ops/sec ±5.63% (69 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 10,594 ops/sec ±3.56% (69 runs sampled)
Fastest is sanity_check
Slowest is build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars

  ․ • sanity_check x 380,047 ops/sec ±1.66% (75 runs sampled)
 • exec_very_simple_machine x 521 ops/sec ±1.24% (73 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 502 ops/sec ±1.27% (76 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 378 ops/sec ±1.88% (71 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 419 ops/sec ±1.60% (73 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 397 ops/sec ±2.31% (73 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 189 ops/sec ±4.95% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 450 ops/sec ±2.41% (69 runs sampled)
Fastest is sanity_check
Slowest is exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
․ • sanity_check x 394,245 ops/sec ±1.82% (74 runs sampled)
 • execSync_very_simple_machine x 6,768 ops/sec ±3.72% (63 runs sampled)
 • execSync_machine_with_inputs_and_exits_but_nothing_crazy x 5,225 ops/sec ±2.88% (67 runs sampled)
 • execSync_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 1,785 ops/sec ±4.44% (69 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits x 2,585 ops/sec ±4.87% (69 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 2,504 ops/sec ±5.60% (67 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 549 ops/sec ±1.88% (72 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 3,503 ops/sec ±5.69% (66 runs sampled)
Fastest is sanity_check
Slowest is execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
```