### PR TITLE
Change setTimeout to setImmediate

### DIFF
--- a/lib/private/intercept-exit-callbacks.js
+++ b/lib/private/intercept-exit-callbacks.js
@@ -167,9 +167,9 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, liveM
           if (liveMachine._runningSynchronously) {
             return proceed();
           }
-          setTimeout(function (){
+          setImmediate(function (){
             return proceed();
-          }, 0);
+          });
 
         })(function afterMaybeWaiting() {
 
@@ -244,7 +244,7 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, liveM
               // ===================================================================================================================
               if (liveMachine._doAlterStack) {
                 // Finally, copy the stack from `thisStack` created at the
-                // beginning of this function _before_ the setTimeout().
+                // beginning of this function _before_ the setImmediate().
 
                 // Set the new error's stack to that of `thisStack`, with the error message prepended.
                 // We prepend the message because the code below that modifies the stack expects


### PR DESCRIPTION
You get a pretty significant performance boost here. Before it was pretty (really) slow. Not it's fast like a cheetah. Here are relevant benchmarks:

**Before Fix:**
```
 • exec_very_simple_machine x 614 ops/sec ±1.78% (73 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 577 ops/sec ±1.47% (74 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 455 ops/sec ±2.26% (73 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 517 ops/sec ±1.92% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 496 ops/sec ±2.26% (68 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 292 ops/sec ±2.92% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 570 ops/sec ±2.17% 
```

**After Fix**
```
• exec_very_simple_machine x 14,510 ops/sec ±2.36% (73 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 10,472 ops/sec ±2.92% (75 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 2,879 ops/sec ±2.58% (77 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 4,097 ops/sec ±4.29% (73 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 4,212 ops/sec ±3.51% (74 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 757 ops/sec ±2.09% (79 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 6,015 ops/sec ±3.75% (69 runs sampled)
```