### PR TITLE
Fix browser usage

### DIFF
--- a/lib/private/intercept-exit-callbacks.js
+++ b/lib/private/intercept-exit-callbacks.js
@@ -167,9 +167,41 @@ module.exports = function interceptExitCallbacks (callbacks, _cache, hash, liveM
           if (liveMachine._runningSynchronously) {
             return proceed();
           }
-          setImmediate(function (){
-            return proceed();
-          });
+
+          //--•
+          // Otherwise, use setImmediate() (or `setTimeout(...,0)` if necesary) to
+          // ensure that at least one tick goes by.
+          //
+          // This is to be sure that it works like:
+          // ```
+          // //1
+          // foo().exec(function (err){
+          //   //3
+          // });
+          // //2
+          // ```
+          //
+          // And never like:
+          // ```
+          // //1
+          // foo().exec(function (err){
+          //   //2
+          // });
+          // //3
+          // ```
+          //
+          // > FUTURE: allow machines to declare some property that skips this-- saying that
+          // > they guarantee that they are ACTUALLY asynchronous (perhaps `sync: false`).
+          if (typeof setImmediate === 'function') {
+            setImmediate(function (){
+              return proceed();
+            });
+          }
+          else {
+            setTimeout(function (){
+              return proceed();
+            });
+          }
 
         })(function afterMaybeWaiting() {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine",
-  "version": "13.0.0-18",
+  "version": "13.0.0-19",
   "description": "Configure and execute machines",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine",
-  "version": "13.0.0-17",
+  "version": "13.0.0-18",
   "description": "Configure and execute machines",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This makes it work in the browser again.

See https://github.com/substack/node-browserify/issues/985#issuecomment-64233128
(This was not supported in browserify)
```
   o                               
                                    
       •                            
      o                  .          
       •                •            
        •                •           
                •       o            
                            •        o
 o   •              •          o   •
      o              o         •    
  •  •      •       •      •    •    
           •      •              o  
  •    b e n c h m a r k s      •    
   •        •                        
 •                        ___  •    
    • o •    •      •    /o/•\_   • 
       •   •  o    •    /_/\ o \_ • 
       o    O   •   o • •   \ o .\_    
          •       o  •       \. O  \   

 • sanity_check x 340,391 ops/sec ±1.34% (81 runs sampled)
 • build_very_simple_machine x 67,217 ops/sec ±2.95% (74 runs sampled)
 • build_machine_with_inputs_and_exits_but_nothing_crazy x 46,535 ops/sec ±2.99% (73 runs sampled)
 • build_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 45,375 ops/sec ±3.28% (72 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits x 30,662 ops/sec ±2.63% (67 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 30,132 ops/sec ±2.49% (72 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 30,483 ops/sec ±2.62% (71 runs sampled)
 • build_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 31,367 ops/sec ±2.36% (72 runs sampled)
Fastest is sanity_check
Slowest is build_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable,build_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars,build_machine_with_crazy_numbers_of_inputs_and_exits

  ․ • sanity_check x 339,568 ops/sec ±1.18% (80 runs sampled)
 • exec_very_simple_machine x 11,553 ops/sec ±2.90% (72 runs sampled)
 • exec_machine_with_inputs_and_exits_but_nothing_crazy x 8,288 ops/sec ±3.21% (72 runs sampled)
 • exec_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 1,612 ops/sec ±2.47% (78 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits x 3,226 ops/sec ±3.26% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 3,203 ops/sec ±3.33% (70 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 369 ops/sec ±2.23% (76 runs sampled)
 • exec_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 4,803 ops/sec ±3.23% (72 runs sampled)
Fastest is sanity_check
Slowest is exec_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
․ • sanity_check x 330,561 ops/sec ±1.38% (82 runs sampled)
 • execSync_very_simple_machine x 11,240 ops/sec ±2.99% (72 runs sampled)
 • execSync_machine_with_inputs_and_exits_but_nothing_crazy x 7,930 ops/sec ±2.98% (74 runs sampled)
 • execSync_machine_with_inputs_and_exits_that_have_big_ole_exemplars x 1,584 ops/sec ±2.59% (78 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits x 3,033 ops/sec ±3.14% (71 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_and_is_cacheable x 3,020 ops/sec ±3.26% (70 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars x 368 ops/sec ±2.38% (76 runs sampled)
 • execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_ref_exemplars x 4,420 ops/sec ±3.07% (71 runs sampled)
Fastest is sanity_check
Slowest is execSync_machine_with_crazy_numbers_of_inputs_and_exits_with_huge_exemplars
․

  3 passing (2m)

```